### PR TITLE
Change command format to "/name" style

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,6 +1,6 @@
 package seedu.address.logic;
 
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,8 +25,9 @@ public class Messages {
     public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
         assert duplicatePrefixes.length > 0;
 
-        Set<String> duplicateFields =
-                Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
+        // Compile the list of duplicate prefixes for error message in natural order
+        List<String> duplicateFields =
+                Stream.of(duplicatePrefixes).map(Prefix::toString).sorted().collect(Collectors.toList());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,10 +6,10 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NAME = new Prefix("/name");
+    public static final Prefix PREFIX_PHONE = new Prefix("/phone");
+    public static final Prefix PREFIX_EMAIL = new Prefix("/email");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("/address");
+    public static final Prefix PREFIX_TAG = new Prefix("/tag");
 
 }


### PR DESCRIPTION
For better clarity of prefixes and more natural UX, the fields are mentioned in full such as "/name" instead of "/n" and the slash is at the front of a field instead of being at the end.

No change to existing fields used.

Error message for duplicate prefixes changed to follow natural ordering such that the prefixes displayed is consistent.