### PR TITLE
Rename edit applicant

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -58,7 +58,7 @@ By using commands, HR officers can efficiently organize contacts for their recru
 * Items in square brackets are optional.<br>
   e.g `/name NAME [/tag TAG]` can be used as `/name John Doe /tag friend` or as `/name John Doe`.
 
-* Parameters can be in any order for `add_applicant` and `edit_applicant` commands.<br>
+* Parameters can be in any order for `add_applicant` and `edit` commands.<br>
   e.g. if the command specifies `/name NAME /phone PHONE_NUMBER`, `/phone PHONE_NUMBER /name NAME` is also acceptable.
 
 * Parameters must be in strict order for `filter`, `note`, `export`, and `tag` command.
@@ -94,11 +94,11 @@ Shows a list of all applicants in the HRConnect.
 
 Format: `list`
 
-### Editing an applicant : `edit_applicant`
+### Editing an applicant : `edit`
 
 Edits an existing applicant in the HRConnect.
 
-Format: `edit_applicant Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`
+Format: `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`
 
 * Edits the applicant at the specified `Index`. The index refers to the index number shown in the displayed applicant list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -108,8 +108,8 @@ Format: `edit_applicant Index [/name Name] [/phone Phone] [/email Email] [/addre
     specifying any tags after it.
 
 Examples:
-*  `edit_applicant 1 /phone 91234567 /email johndoe@example.com` Edits the phone number and email address of the 1st applicant to be `91234567` and `johndoe@example.com` respectively.
-*  `edit_applicant 2 /name Betsy Crower /tag` Edits the name of the 2nd applicant to be `Betsy Crower` and clears all existing tags.
+*  `edit 1 /phone 91234567 /email johndoe@example.com` Edits the phone number and email address of the 1st applicant to be `91234567` and `johndoe@example.com` respectively.
+*  `edit 2 /name Betsy Crower /tag` Edits the name of the 2nd applicant to be `Betsy Crower` and clears all existing tags.
 
 ### Locating applicants by name: `find`
 
@@ -220,7 +220,7 @@ Action | Format, Examples
 **Add_applicant** | `add_applicant /name Name /phone Phone_Number /email Email /address Address /role Role [/tag Tag]…​` <br> e.g., `add_applicant /name James Chow /phone 96622612 /email james@example.com /address 321, Clementi Ave 2, #02-25 /role Junior Engineer`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit_applicant** | `edit_applicant Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`<br> e.g., `edit_applicant 2 /stage waitlisted`
+**Edit** | `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`<br> e.g., `edit 2 /stage waitlisted`
 **Find** | `find Keyword [More_Keywords]`<br> e.g., `find alice bob charlie`
 **List** | `list`
 **Help** | `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,7 +98,8 @@ Format: `list`
 
 Edits an existing applicant in the HRConnect.
 
-Format: `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`
+Format: `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] 
+[/note Note] [/role Role] [/tag Tag]…​`
 
 * Edits the applicant at the specified `Index`. The index refers to the index number shown in the displayed applicant list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -220,7 +221,7 @@ Action | Format, Examples
 **Add_applicant** | `add_applicant /name Name /phone Phone_Number /email Email /address Address /role Role [/tag Tag]…​` <br> e.g., `add_applicant /name James Chow /phone 96622612 /email james@example.com /address 321, Clementi Ave 2, #02-25 /role Junior Engineer`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit** | `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/tag Tag]…​`<br> e.g., `edit 2 /stage waitlisted`
+**Edit** | `edit Index [/name Name] [/phone Phone] [/email Email] [/address Address] [/stage Stage] [/role Role] [/note Note] [/tag Tag]…​`<br> e.g., `edit 2 /stage waitlisted`
 **Find** | `find Keyword [More_Keywords]`<br> e.g., `find alice bob charlie`
 **List** | `list`
 **Help** | `help`

--- a/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApplicantCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STAGE;
@@ -39,7 +40,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditApplicantCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit_applicant";
+    public static final String COMMAND_WORD = "edit";
     public static final String DEFAULT_ROLE = "SWE";
     public static final String DEFAULT_STAGE = "initial_application";
 
@@ -55,6 +56,7 @@ public class EditApplicantCommand extends Command {
             + "[" + PREFIX_ADDRESS + " ADDRESS] "
             + "[" + PREFIX_ROLE + " ROLE] "
             + "[" + PREFIX_STAGE + " STAGE] "
+            + "[" + PREFIX_NOTE + " NOTE] "
             + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + " 91234567 "
@@ -63,7 +65,7 @@ public class EditApplicantCommand extends Command {
             + PREFIX_STAGE + " final_round "
             + PREFIX_ROLE + " SWE "
             + PREFIX_TAG + " friends "
-            + PREFIX_TAG + " owesMoney";
+            + PREFIX_NOTE + " 4 Week Notice";
 
     public static final String MESSAGE_EDIT_APPLICANT_SUCCESS = "Edited Applicant: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/test/java/seedu/address/logic/commands/EditApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApplicantCommandTest.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_CHLOE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_CHLOE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STAGE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STAGE_CHLOE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -48,6 +52,33 @@ public class EditApplicantCommandTest {
     }
 
     @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        Applicant lastApplicant = new ApplicantBuilder(lastPerson).build();
+
+        ApplicantBuilder applicantInList = new ApplicantBuilder(lastApplicant);
+        Applicant editedApplicant =
+                applicantInList.withRole(VALID_ROLE_CHLOE).withStage(VALID_STAGE_BOB).build();
+
+        EditApplicantCommand.EditApplicantDescriptor descriptor =
+                new EditApplicantDescriptorBuilder().withRole(VALID_ROLE_CHLOE).withStage(VALID_STAGE_BOB).build();
+
+        EditApplicantCommand editApplicantCommand = new EditApplicantCommand(indexLastPerson,
+                descriptor);
+
+        String expectedMessage = String.format(EditApplicantCommand.MESSAGE_EDIT_APPLICANT_SUCCESS,
+                Messages.format(editedApplicant));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedApplicant);
+
+        assertCommandSuccess(editApplicantCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditApplicantCommand editApplicantCommand = new EditApplicantCommand(INDEX_FIRST_PERSON,
                 new EditApplicantCommand.EditApplicantDescriptor());
@@ -83,7 +114,6 @@ public class EditApplicantCommandTest {
     }
 
 
-
     /**
      * Edit filtered list where index is larger than size of filtered list,
      * but smaller than size of address book
@@ -100,6 +130,49 @@ public class EditApplicantCommandTest {
 
         assertCommandFailure(editApplicantCommand, model,
                 Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditApplicantCommand standardCommand = new EditApplicantCommand(INDEX_FIRST_PERSON,
+                DESC_CHLOE);
+
+        // same values -> returns true
+        EditApplicantCommand.EditApplicantDescriptor copyDescriptor =
+                new EditApplicantCommand.EditApplicantDescriptor(DESC_CHLOE);
+        EditApplicantCommand commandWithSameValues = new EditApplicantCommand(INDEX_FIRST_PERSON,
+                copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditApplicantCommand(INDEX_SECOND_PERSON,
+                DESC_CHLOE)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditApplicantCommand.EditApplicantDescriptor editApplicantDescriptor =
+                new EditApplicantCommand.EditApplicantDescriptor();
+        EditApplicantCommand editApplicantCommand = new EditApplicantCommand(index,
+                editApplicantDescriptor);
+        String expected = EditApplicantCommand.class.getCanonicalName()
+                + "{index="
+                + index
+                + ", "
+                + "editApplicantDescriptor="
+                + editApplicantDescriptor
+                + "}";
+        assertEquals(expected, editApplicantCommand.toString());
     }
 
 


### PR DESCRIPTION
Renamed edit_applicant to applicant on UserGuide and on EditApplicantCommand. Included a few more test cases too.